### PR TITLE
chore(docs): fix design tokens build command in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ A production-ready Storybook environment for demonstrating Figma MCP component g
    npm install
    ```
 
-2. Build design tokens (or leave running for auto-rebuild):
+2. Build design tokens:
    ```bash
-   npm run tokens:build
+   npm run tokens
    ```
+   (or leave `npm run tokens:watch` running for auto-rebuild)
 
 3. Start Storybook:
    ```bash
@@ -27,7 +28,7 @@ npm run dev
 ## Token Management
 
 Paste CBDS token exports into `tokens/json/*.json` keeping the same key structure. 
-Run `tokens:build` to regenerate CSS variables.
+Run `tokens` to regenerate CSS variables.
 
 ## Theme Switching
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -105,7 +105,7 @@ const primaryBg: CBDSVar = '--cbds-bg-brand-default';
 The tokens are automatically built when you run:
 
 ```bash
-npm run tokens:build
+npm run tokens
 ```
 
 This command:
@@ -134,7 +134,7 @@ Examples:
 
 1. **Edit tokens** in Token Studio or directly in the JSON files
 2. **Export from Token Studio** to `tokens/json/` (if using Token Studio)
-3. **Run build** with `npm run tokens:build`
+3. **Run build** with `npm run tokens`
 4. **Use tokens** in components via CSS custom properties
 5. **Test themes** by switching the `data-theme` attribute
 


### PR DESCRIPTION
The `tokens:build` script doesn't exist, and running `npm run tokens:build` returns an error.

This PR updates the instructions, but it may make sense to change the name of the script `tokens` to `tokens:build` in package.json instead.